### PR TITLE
Feat: Delete Board

### DIFF
--- a/apps/backend/src/board/board.controller.ts
+++ b/apps/backend/src/board/board.controller.ts
@@ -2,9 +2,12 @@ import {
   Body,
   ConflictException,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
+  NotFoundException,
+  Param,
   Post,
   Req,
   Response,
@@ -43,6 +46,19 @@ export class BoardController {
       if (error instanceof Prisma.PrismaClientKnownRequestError)
         if (error.code === 'P2002') throw new ConflictException();
       throw error;
+    }
+  }
+
+  @Delete(':id')
+  async deleteBoard(@Param('id') id: number) {
+    try {
+      await this.boardService.delete(id);
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError) {
+        if (e.code === 'P2025' || e.code === 'P2016') {
+          return new NotFoundException();
+        }
+      }
     }
   }
 }

--- a/apps/backend/src/board/board.controller.ts
+++ b/apps/backend/src/board/board.controller.ts
@@ -50,15 +50,16 @@ export class BoardController {
   }
 
   @Delete(':id')
-  async deleteBoard(@Param('id') id: number) {
+  async deleteBoard(@Req() request, @Param('id') id: string) {
     try {
-      await this.boardService.delete(id);
+      await this.boardService.delete(Number.parseInt(id), request.user.UserId);
     } catch (e) {
       if (e instanceof Prisma.PrismaClientKnownRequestError) {
         if (e.code === 'P2025' || e.code === 'P2016') {
-          return new NotFoundException();
+          throw new NotFoundException();
         }
       }
+      throw e;
     }
   }
 }

--- a/apps/backend/src/board/board.service.ts
+++ b/apps/backend/src/board/board.service.ts
@@ -26,10 +26,11 @@ export class BoardService {
     return slug;
   }
 
-  async delete(id: number): Promise<void> {
+  async delete(id: number, UserId: number): Promise<void> {
     await this.db.board.delete({
       where: {
         Id: id,
+        OwnerId: UserId,
       },
     });
   }

--- a/apps/backend/src/board/board.service.ts
+++ b/apps/backend/src/board/board.service.ts
@@ -26,6 +26,14 @@ export class BoardService {
     return slug;
   }
 
+  async delete(id: number): Promise<void> {
+    await this.db.board.delete({
+      where: {
+        Id: id,
+      },
+    });
+  }
+
   async get(
     userId: number,
     collaborated: boolean = false,

--- a/apps/frontend/src/app/components/board-list/board-list.component.html
+++ b/apps/frontend/src/app/components/board-list/board-list.component.html
@@ -4,8 +4,11 @@
       <li
         [class]="`${ !board.collaborated ? `bg-primary-900`: 'bg-purple-900' } aspect-[4/2] p-4 text-white flex flex-col justify-end rounded-2xl`"
       >
-        <div class="flex-1 text-right">
+        <div class="flex-1 flex flex-col gap-2 text-right">
           <a [routerLink]="`/board/${board.slug}`"><i class="pi pi-external-link"></i></a>
+          @if (!board.collaborated) {
+            <i class="pi pi-trash cursor-pointer" (click)="handleDelete(board.id, board.title)"></i>
+          }
         </div>
         <div>
           <h3 class="text-lg font-semibold max-w-full truncate">{{ board.title }}</h3>

--- a/apps/frontend/src/app/components/board-list/board-list.component.html
+++ b/apps/frontend/src/app/components/board-list/board-list.component.html
@@ -26,3 +26,27 @@
     }
   }
 </ul>
+
+<!-- Board Deletion Confirmation Dialog -->
+<p-confirmdialog #cd>
+  <ng-template #headless let-message let-onAccept="onAccept" let-onReject="onReject">
+    <div class="flex flex-col items-center p-8 bg-surface-0 dark:bg-surface-900 rounded">
+      <div
+        class="rounded-full bg-primary text-primary-contrast inline-flex justify-center items-center h-24 w-24 -mt-20"
+      >
+        <i class="pi pi-trash !text-5xl"></i>
+      </div>
+      <span class="font-bold text-2xl block mb-2 mt-6">{{ message.header }}</span>
+      <p class="mb-0">{{ message.message }}</p>
+      <div class="flex items-center gap-2 mt-6">
+        <p-button label="Delete" (onClick)="onAccept()" styleClass="w-32"></p-button>
+        <p-button
+          label="Cancel"
+          [outlined]="true"
+          (onClick)="onReject()"
+          styleClass="w-32"
+        ></p-button>
+      </div>
+    </div>
+  </ng-template>
+</p-confirmdialog>

--- a/apps/frontend/src/app/components/board-list/board-list.component.ts
+++ b/apps/frontend/src/app/components/board-list/board-list.component.ts
@@ -63,4 +63,16 @@ export class BoardListComponent implements OnInit {
         },
       });
   }
+
+  handleDelete(id: number, title: string) {
+    this.boardService.delete(id).subscribe({
+      next: () => {
+        this.boards.update((prev) => prev.filter((val) => val.id !== id));
+        this.toast.success('Board', `Successfully Deleted ${title}`);
+      },
+      error: (error: Error) => {
+        this.toast.error('Board', error.message);
+      },
+    });
+  }
 }

--- a/apps/frontend/src/app/services/board.service.ts
+++ b/apps/frontend/src/app/services/board.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { catchError, map, Observable, throwError, timer } from 'rxjs';
+import { catchError, map, Observable, of, throwError, timer } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { Board } from '../types/board';
 
@@ -15,6 +15,15 @@ export class BoardService {
       catchError((error: HttpErrorResponse) => {
         return throwError(() => new Error('Something went wrong. Please try again later'));
       }),
+    );
+  }
+
+  delete(id: number): Observable<boolean> {
+    return this.http.delete(`${environment.apiUrl}/board/${id}`, { withCredentials: true }).pipe(
+      map(() => true),
+      catchError(() =>
+        throwError(() => new Error('Unable to delete Board. Please try again later.')),
+      ),
     );
   }
 


### PR DESCRIPTION
## Description
This pull request introduces functionality for deleting boards, including backend API support, frontend UI updates, and service integration. The changes span both backend and frontend codebases, adding a new `deleteBoard` method in the backend and a confirmation dialog in the frontend for board deletion. Below is a summary of the most important changes grouped by theme.

### Backend Changes (Board Deletion API):

* **Added `deleteBoard` endpoint in `BoardController`:** A new `@Delete(':id')` route was added to handle board deletion requests. It validates the `id` parameter and checks for ownership before deleting the board. If the board is not found, a `NotFoundException` is thrown.
* **Implemented `delete` method in `BoardService`:** The `BoardService` now includes a `delete` method that interacts with the database to delete a board based on its `id` and `OwnerId`.

### Frontend Changes (Board Deletion UI):

* **Added delete icon and confirmation dialog in `BoardListComponent`:** The board list UI now includes a trash icon for non-collaborative boards, which triggers a confirmation dialog for deletion. The dialog uses PrimeNG's `ConfirmDialog` component.
* **Updated `BoardListComponent` logic for handling deletion:** A new `handleDelete` method was added to manage the confirmation process and call the `BoardService` to delete the board. It updates the board list and displays success/error messages using `ToastService`.

### Frontend Service Changes:

* **Added `delete` method in `BoardService`:** The `BoardService` now includes a `delete` method to send HTTP DELETE requests to the backend API for board deletion. It handles errors and returns an observable indicating success.

## Issue
closes #11 