### PR TITLE
feat: Added Board Edit Feature

### DIFF
--- a/apps/backend/src/board/board.controller.ts
+++ b/apps/backend/src/board/board.controller.ts
@@ -8,6 +8,7 @@ import {
   HttpStatus,
   NotFoundException,
   Param,
+  Patch,
   Post,
   Req,
   Response,
@@ -18,6 +19,7 @@ import { CreateBoardDto, CreateBoardResponseDto } from './dto/createBoard.dto';
 import { plainToInstance } from 'class-transformer';
 import { Prisma } from 'generated/prisma';
 import { GetBoardDto } from './dto/getBoard.dto';
+import { UpdateBoardDto } from './dto/updateBoard.dto';
 
 @Controller('board')
 export class BoardController {
@@ -53,6 +55,27 @@ export class BoardController {
   async deleteBoard(@Req() request, @Param('id') id: string) {
     try {
       await this.boardService.delete(Number.parseInt(id), request.user.UserId);
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError) {
+        if (e.code === 'P2025' || e.code === 'P2016') {
+          throw new NotFoundException();
+        }
+      }
+      throw e;
+    }
+  }
+
+  @Patch(':id')
+  async updateBoard(
+    @Req() request,
+    @Param('id') id: string,
+    @Body() updateBoardDto: UpdateBoardDto,
+  ) {
+    try {
+      await this.boardService.update(Number.parseInt(id), request.user.UserId, {
+        Name: updateBoardDto.title,
+        Description: updateBoardDto.description,
+      });
     } catch (e) {
       if (e instanceof Prisma.PrismaClientKnownRequestError) {
         if (e.code === 'P2025' || e.code === 'P2016') {

--- a/apps/backend/src/board/board.service.ts
+++ b/apps/backend/src/board/board.service.ts
@@ -26,6 +26,23 @@ export class BoardService {
     return slug;
   }
 
+  async update(
+    id: number,
+    UserId: number,
+    payload: Pick<Board, 'Name' | 'Description'>,
+  ) {
+    await this.db.board.update({
+      where: {
+        Id: id,
+        OwnerId: UserId,
+      },
+      data: {
+        Name: payload.Name,
+        Description: payload.Description,
+      },
+    });
+  }
+
   async delete(id: number, UserId: number): Promise<void> {
     await this.db.board.delete({
       where: {

--- a/apps/backend/src/board/dto/updateBoard.dto.ts
+++ b/apps/backend/src/board/dto/updateBoard.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateBoardDto {
+  @IsString()
+  title: string;
+
+  @IsString()
+  @IsOptional()
+  description: string;
+}

--- a/apps/frontend/src/app/components/board-list/board-list.component.html
+++ b/apps/frontend/src/app/components/board-list/board-list.component.html
@@ -4,15 +4,21 @@
       <li
         [class]="`${ !board.collaborated ? `bg-primary-900`: 'bg-purple-900' } aspect-[4/2] p-4 text-white flex flex-col justify-end rounded-2xl`"
       >
-        <div class="flex-1 flex flex-col gap-2 text-right">
+        <div class="flex-1 flex flex-col gap-2 items-end">
           <a [routerLink]="`/board/${board.slug}`"><i class="pi pi-external-link"></i></a>
           @if (!board.collaborated) {
             <i class="pi pi-trash cursor-pointer" (click)="handleDelete(board.id, board.title)"></i>
           }
         </div>
-        <div>
+        <div class="relative">
           <h3 class="text-lg font-semibold max-w-full truncate">{{ board.title }}</h3>
           <p class="max-w-full truncate">{{ board.description }}</p>
+          @if (!board.collaborated) {
+            <i
+              class="pi pi-pencil absolute bottom-1 right-0 cursor-pointer"
+              (click)="handleEditStart(board)"
+            ></i>
+          }
         </div>
       </li>
     } @empty {
@@ -50,3 +56,39 @@
     </div>
   </ng-template>
 </p-confirmdialog>
+
+<!-- Edit Dialog -->
+<p-dialog
+  header="Edit Board"
+  [modal]="true"
+  [(visible)]="IsEditDialogVisible"
+  [style]="{ width: '25rem' }"
+  (onHide)="handleEditDiscard()"
+>
+  <form [formGroup]="EditForm" (ngSubmit)="handleEditSave()">
+    <p-floatlabel variant="on" class="my-4">
+      <label for="title">Title</label>
+      <input type="text" class="w-full" id="title" pInputText formControlName="title" />
+    </p-floatlabel>
+    <p-floatlabel variant="on" class="mb-4">
+      <label for="description">Description (optional)</label>
+      <textarea
+        rows="5"
+        id="description"
+        fluid
+        pTextarea
+        formControlName="description"
+        class="resize-none"
+      ></textarea>
+    </p-floatlabel>
+    <div class="flex justify-end gap-2">
+      <p-button label="Cancel" severity="secondary" (onClick)="handleEditDiscard()" />
+      <p-button
+        label="Save"
+        type="submit"
+        [disabled]="!this.EditForm.valid"
+        [loading]="editSaveLoading()"
+      />
+    </div>
+  </form>
+</p-dialog>

--- a/apps/frontend/src/app/components/board-list/board-list.component.ts
+++ b/apps/frontend/src/app/components/board-list/board-list.component.ts
@@ -3,28 +3,62 @@ import { RouterModule } from '@angular/router';
 import { SkeletonModule } from 'primeng/skeleton';
 import { BoardService } from '../../services/board.service';
 import { Board } from '../../types/board';
-import { delay, finalize } from 'rxjs';
+import { delay, finalize, timer } from 'rxjs';
 import { ToastService } from '../../services/toast.service';
 import { ConfirmDialog } from 'primeng/confirmdialog';
 import { ButtonModule } from 'primeng/button';
 import { ConfirmationService } from 'primeng/api';
+import { DialogModule } from 'primeng/dialog';
+import { InputTextModule } from 'primeng/inputtext';
+import { FloatLabelModule } from 'primeng/floatlabel';
+import { TextareaModule } from 'primeng/textarea';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+
+interface BoardFormValue {
+  id: number | null;
+  title: string;
+  description?: string;
+}
 
 @Component({
   selector: 'app-board-list',
-  imports: [RouterModule, SkeletonModule, ConfirmDialog, ButtonModule],
+  imports: [
+    RouterModule,
+    SkeletonModule,
+    ConfirmDialog,
+    ButtonModule,
+    DialogModule,
+    InputTextModule,
+    FloatLabelModule,
+    TextareaModule,
+    ReactiveFormsModule,
+  ],
   providers: [ConfirmationService],
   templateUrl: './board-list.component.html',
   styleUrl: './board-list.component.css',
 })
 export class BoardListComponent implements OnInit {
+  // Required Services
   boardService = inject(BoardService);
   injector = inject(Injector);
   toast = inject(ToastService);
 
+  // Filtering Search Term
   searchTerm = input('');
 
+  // Global Card Loading
   loading = signal<boolean>(true);
 
+  // Edit States
+  editSaveLoading = signal<boolean>(false);
+  IsEditDialogVisible = signal<boolean>(false);
+  EditForm = new FormGroup({
+    id: new FormControl<number | null>(null), // Hidden Field
+    title: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    description: new FormControl(''),
+  });
+
+  // Board Data
   boards = signal<Board[]>([]);
   filteredBoards = computed<Board[]>(() =>
     this.boards().filter(
@@ -68,5 +102,49 @@ export class BoardListComponent implements OnInit {
         });
       },
     });
+  }
+
+  handleEditStart(board: Board) {
+    this.EditForm.controls.id.setValue(board.id);
+    this.EditForm.controls.title.setValue(board.title);
+    this.EditForm.controls.description.setValue(board.description || null);
+    this.IsEditDialogVisible.set(true);
+  }
+
+  handleEditSave() {
+    const formValue = this.EditForm.value as BoardFormValue;
+
+    if (formValue.id === null) {
+      this.toast.error('Internal Error', 'Something went wrong. Please try again later');
+      return;
+    }
+
+    this.editSaveLoading.set(true);
+    this.boardService.update(formValue.id, formValue.title, formValue.description).subscribe({
+      next: () => {
+        // Update Local State
+        this.boards.update((prev) =>
+          prev.map((board) =>
+            board.id === formValue.id
+              ? { ...board, title: formValue.title, description: formValue.description }
+              : board,
+          ),
+        );
+
+        this.toast.success('Board', 'Successfully Updated Board Details');
+        this.editSaveLoading.set(false);
+        this.IsEditDialogVisible.set(false);
+        this.EditForm.reset({ id: null, title: '', description: undefined });
+      },
+      error: (error: Error) => {
+        this.toast.error('Error', error.message);
+        this.editSaveLoading.set(false);
+      },
+    });
+  }
+
+  handleEditDiscard() {
+    this.IsEditDialogVisible.set(false);
+    this.EditForm.reset({ id: null, title: '', description: undefined });
   }
 }

--- a/apps/frontend/src/app/services/board.service.ts
+++ b/apps/frontend/src/app/services/board.service.ts
@@ -18,6 +18,17 @@ export class BoardService {
     );
   }
 
+  update(id: number, title: string, description?: string): Observable<boolean> {
+    return this.http
+      .patch(`${environment.apiUrl}/board/${id}`, { title, description }, { withCredentials: true })
+      .pipe(
+        map(() => true),
+        catchError(() =>
+          throwError(() => new Error('Something went wrong. Please try again later.')),
+        ),
+      );
+  }
+
   delete(id: number): Observable<boolean> {
     return this.http.delete(`${environment.apiUrl}/board/${id}`, { withCredentials: true }).pipe(
       map(() => true),


### PR DESCRIPTION
## Description

This pull request introduces functionality to update board details, including both backend and frontend changes. The backend now supports updating board information via a new `PATCH` endpoint, while the frontend provides an interface for users to edit board details directly. Key updates include the addition of the `UpdateBoardDto`, a new method in the backend's `BoardService`, and an edit dialog in the frontend's `BoardListComponent`.

### Backend Changes:
* **New `PATCH` Endpoint for Board Updates**: Added a `@Patch(':id')` method in `BoardController` to handle board updates. This method validates input using `UpdateBoardDto` and interacts with the `BoardService` to update board details in the database.
* **Update Method in `BoardService`**: Introduced an `update` method in `BoardService` to modify board details, ensuring changes are scoped to the board's owner.
* **DTO for Board Updates**: Created `UpdateBoardDto` with validation rules for `title` and optional `description` fields.

### Frontend Changes:
* **Edit Dialog in `BoardListComponent`**: Added an edit dialog to allow users to update board details. This includes form controls for `title` and `description`, along with save and cancel buttons.
* **Edit Handling Logic**: Implemented methods in `BoardListComponent` to manage the edit dialog's visibility, handle form submissions, and update the local state upon successful board edits.
* **Frontend Service Update Method**: Added an `update` method in the frontend's `BoardService` to send `PATCH` requests to the backend for board updates.

## Issue
#12 